### PR TITLE
Convenience of accessing app data (Ubiquity) in iCloud drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ John [{u'field': u'+1 555-55-5555-5', u'label': u'MOBILE'}]
 
 ## File Storage (Ubiquity)
 
+**NOTE: It seems like having app documents are no longer stored in Ubiquity [and migrated to iCloud Drive](https://developer.apple.com/library/archive/technotes/tn2348/_index.html). See below.**
+
 You can access documents stored in your iCloud account by using the `files` property's `dir` method:
 
 ```bash
@@ -318,6 +320,21 @@ The `upload` method can be used to send a file-like object to the iCloud Drive:
 
 It is strongly suggested to open file handles as binary rather than text to prevent decoding errors
 further down the line.
+
+### Accessing App Data
+The `get_app_node` method can be used to retrieve a node with app data (that is not shown in `api.drive.dir()`). This is where the individual apps store related documents.
+
+```bash
+>>> node = api.drive.get_app_node("XXXXXXXXXX.com.apple.iMovie")
+```
+Ids of individual app data can be found in `~/Library/Mobile Documents` (can only be accessed in Terminal). `~` must be replaced with `.`.
+
+Node can then be used just like any other node, supporting `mkdir`, `rename`, `delete` and so on:
+```
+>>> node.mkdir('2020')
+>>> node.rename('2020_copy')
+>>> node.delete()
+```
 
 ## Photo Library
 

--- a/icloudpy/services/drive.py
+++ b/icloudpy/services/drive.py
@@ -21,6 +21,10 @@ class DriveService:
         self.params = dict(params)
         self._root = None
 
+    def get_app_node(self, app_id, folder="documents"):
+        """Returns the node of the app (ubiquity)"""
+        return DriveNode(self, self.get_node_data("FOLDER::" + app_id + "::" + folder))
+
     def _get_token_from_cookie(self):
         for cookie in self.session.cookies:
             if cookie.name == "X-APPLE-WEBAUTH-VALIDATE":

--- a/icloudpy/services/drive.py
+++ b/icloudpy/services/drive.py
@@ -21,10 +21,6 @@ class DriveService:
         self.params = dict(params)
         self._root = None
 
-    def get_app_node(self, app_id, folder="documents"):
-        """Returns the node of the app (ubiquity)"""
-        return DriveNode(self, self.get_node_data("FOLDER::" + app_id + "::" + folder))
-
     def _get_token_from_cookie(self):
         for cookie in self.session.cookies:
             if cookie.name == "X-APPLE-WEBAUTH-VALIDATE":
@@ -79,6 +75,10 @@ class DriveService:
         if not request.ok:
             self.session.raise_error(request.status_code, request.reason)
         return request.json()["items"]
+
+    def get_app_node(self, app_id, folder="documents"):
+        """Returns the node of the app (ubiquity)"""
+        return DriveNode(self, self.get_node_data("FOLDER::" + app_id + "::" + folder))
 
     def _get_upload_contentws_url(self, file_object, zone="com.apple.CloudDocs"):
         """Get the contentWS endpoint URL to add a new file."""


### PR DESCRIPTION
It seems like ubiquity file storage has become obsolete for a quite a while and all the app datas are stored under iCloud Drive (but in different zone) now. Hence, there had been many issues when accessing ubiquity via this library (and pyicloud). Related issue: #18 and https://github.com/picklepete/pyicloud/issues/333

This pull request aims to clear up the confusion and makes it easier for users to access app datas that they were previously able to get from ubiquity. `get_app_node` returns a `DriveNode` that can be used just like any other drive nodes.

Perhaps a readme to this change could also be added to avoid further confusion, although I'm not entirely certain if ubiquity can be marked as entirely "obsolete".