### PR TITLE
Ability to download raw version of photo

### DIFF
--- a/icloudpy/services/photos.py
+++ b/icloudpy/services/photos.py
@@ -573,15 +573,21 @@ class PhotoAsset:
         self._versions = None
 
     PHOTO_VERSION_LOOKUP = {
-        "original": "resOriginal",
+        "full": "resJPEGFull",
+        "large": "resJPEGLarge",
         "medium": "resJPEGMed",
         "thumb": "resJPEGThumb",
+        "sidecar": "resSidecar",
+        "original": "resOriginal",
+        "original_alt": "resOriginalAlt",
     }
 
     VIDEO_VERSION_LOOKUP = {
-        "original": "resOriginal",
+        "full": "resVidFull",
         "medium": "resVidMed",
         "thumb": "resVidSmall",
+        "original": "resOriginal",
+        "original_compl": "resOriginalVidCompl",
     }
 
     @property


### PR DESCRIPTION
Some imported photos are jpeg+raw combined. The original is jpeg version by default which is saved by icloudpy. However, raw file is actually wanted. We can exchange raw version as original in Mac 'Photos' app but it is too slow to do it one by one. ([link](https://support.apple.com/en-hk/guide/photos/phtbb0eb4eb1/mac)) It is much better if we can download raw as a option.

