### PR TITLE
drive: added refresh of child objects after mkdir

### DIFF
--- a/icloudpy/base.py
+++ b/icloudpy/base.py
@@ -253,8 +253,10 @@ class ICloudPyService:
             LOGGER.info("Session file does not exist")
         if self.session_data.get("client_id"):
             self.client_id = self.session_data.get("client_id")
+            self.params["clientId"] = self.client_id
         else:
             self.session_data.update({"client_id": self.client_id})
+            self.params["clientId"] = self.client_id
 
         self.session = ICloudPySession(self)
         self.session.verify = verify

--- a/icloudpy/services/drive.py
+++ b/icloudpy/services/drive.py
@@ -329,6 +329,10 @@ class DriveNode:
 
     def mkdir(self, folder):
         """Create a new directory directory."""
+        # remove cached entries information first so that it will be re-read on next get_children()
+        self._children = None
+        if "items" in self.data:
+            self.data.pop("items")
         return self.connection.create_folders(self.data["drivewsid"], folder)
 
     def rename(self, name):

--- a/tests/const_drive.py
+++ b/tests/const_drive.py
@@ -655,6 +655,71 @@ DRIVE_SUBFOLDER_WORKING = [
     }
 ]
 
+DRIVE_SUBFOLDER_WORKING_AFTER_MKDIR = [
+    {
+        "drivewsid": "FOLDER::com.apple.CloudDocs::D5AA0425-E84F-4501-AF5D-60F1D92648CF",
+        "docwsid": "D5AA0425-E84F-4501-AF5D-60F1D92648CF",
+        "zone": "com.apple.CloudDocs",
+        "name": "Test",
+        "parentId": "FOLDER::com.apple.CloudDocs::1C7F1760-D940-480F-8C4F-005824A4E05B",
+        "etag": "2z",
+        "type": "FOLDER",
+        "assetQuota": 42199575,
+        "fileCount": 2,
+        "shareCount": 0,
+        "shareAliasCount": 0,
+        "directChildrenCount": 2,
+        "items": [
+            {
+                "drivewsid": "FILE::com.apple.CloudDocs::33A41112-4131-4938-9691-7F356CE3C51D",
+                "docwsid": "33A41112-4131-4938-9691-7F356CE3C51D",
+                "zone": "com.apple.CloudDocs",
+                "name": "Document scanné 2",
+                "parentId": "FOLDER::com.apple.CloudDocs::D5AA0425-E84F-4501-AF5D-60F1D92648CF",
+                "dateModified": "2020-04-27T21:37:36Z",
+                "dateChanged": "2020-04-27T14:44:29-07:00",
+                "size": 19876991,
+                "etag": "2k::2j",
+                "extension": "pdf",
+                "hiddenExtension": True,
+                "lastOpenTime": "2020-04-27T21:37:36Z",
+                "type": "FILE",
+            },
+            {
+                "drivewsid": "FILE::com.apple.CloudDocs::516C896C-6AA5-4A30-B30E-5502C2333DAE",
+                "docwsid": "516C896C-6AA5-4A30-B30E-5502C2333DAE",
+                "zone": "com.apple.CloudDocs",
+                "name": "Scanned document 1",
+                "parentId": "FOLDER::com.apple.CloudDocs::D5AA0425-E84F-4501-AF5D-60F1D92648CF",
+                "dateModified": "2020-05-03T00:15:17Z",
+                "dateChanged": "2020-05-02T17:16:17-07:00",
+                "size": 21644358,
+                "etag": "32::2x",
+                "extension": "pdf",
+                "hiddenExtension": True,
+                "lastOpenTime": "2020-05-03T00:24:25Z",
+                "type": "FILE",
+            },
+            {
+                "drivewsid": "FOLDER::com.apple.CloudDocs::D5AA0425-E84F-4501-AF5D-60F1D92648EF",
+                "docwsid": "D5AA0425-E84F-4501-AF5D-60F1D92648EF",
+                "zone": "com.apple.CloudDocs",
+                "name": "sub_dir",
+                "parentId": "FOLDER::com.apple.CloudDocs::D5AA0425-E84F-4501-AF5D-60F1D92648CF",
+                "etag": "2z",
+                "type": "FOLDER",
+                "assetQuota": 42199575,
+                "fileCount": 0,
+                "shareCount": 0,
+                "shareAliasCount": 0,
+                "directChildrenCount": 0,
+                "items": [],
+            },
+        ],
+        "numberOfItems": 3,
+    }
+]
+
 DRIVE_FILE_DOWNLOAD_WORKING = {
     "document_id": "516C896C-6AA5-4A30-B30E-5502C2333DAE",
     "data_token": {

--- a/tests/test_drive.py
+++ b/tests/test_drive.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 import pytest
 
 from . import ICloudPyServiceMock
-from .const import AUTHENTICATED_USER, VALID_PASSWORD
+from .const import AUTHENTICATED_USER, VALID_PASSWORD, CLIENT_ID
 
 
 # pylint: disable=pointless-statement
@@ -15,7 +15,7 @@ class DriveServiceTest(TestCase):
 
     def setUp(self):
         """Set up test."""
-        self.service = ICloudPyServiceMock(AUTHENTICATED_USER, VALID_PASSWORD)
+        self.service = ICloudPyServiceMock(AUTHENTICATED_USER, VALID_PASSWORD, None, True, CLIENT_ID)
 
     def test_root(self):
         """Test the root folder."""
@@ -84,3 +84,14 @@ class DriveServiceTest(TestCase):
         file_test = self.service.drive["iCloudPy"]["Test"]["Scanned document 1.pdf"]
         with file_test.open(stream=True) as response:
             assert response.raw
+
+    def test_mkdir(self):
+        """Test the /iCloudPy/Test folder."""
+        folder = self.service.drive["iCloudPy"]["Test"]
+        sub_folder_name = "sub_dir"
+        assert folder.dir() == ["Document scanné 2.pdf", "Scanned document 1.pdf"]
+        folder.mkdir(sub_folder_name)
+        sub_folder = folder.get(sub_folder_name)
+        assert sub_folder.name == sub_folder_name
+        assert sub_folder.type == "folder"
+        assert folder.dir() == ["Document scanné 2.pdf", "Scanned document 1.pdf", sub_folder_name]


### PR DESCRIPTION
Use-case:
* init drive service
* mkdir() on some folder
* get list of sub-folders with get()

Expected:
* get() returns list of all sub-folders, including the recently added

Actual:
* get() returns the same list of sub-folders
