### PR TITLE
Fix calendar sync failing on months having 1st day as Monday

### DIFF
--- a/icloudpy/services/calendar.py
+++ b/icloudpy/services/calendar.py
@@ -1,5 +1,4 @@
 """Calendar service."""
-
 from calendar import monthrange
 from datetime import datetime
 

--- a/icloudpy/services/calendar.py
+++ b/icloudpy/services/calendar.py
@@ -1,4 +1,5 @@
 """Calendar service."""
+
 from calendar import monthrange
 from datetime import datetime
 
@@ -46,9 +47,9 @@ class CalendarService:
         have been given, the range becomes this month.
         """
         today = datetime.today()
-        first_day, last_day = monthrange(today.year, today.month)
+        _, last_day = monthrange(today.year, today.month)
         if not from_dt:
-            from_dt = datetime(today.year, today.month, first_day)
+            from_dt = datetime(today.year, today.month, 1)
         if not to_dt:
             to_dt = datetime(today.year, today.month, last_day)
         params = dict(self.params)
@@ -76,8 +77,8 @@ class CalendarService:
         Retrieves calendars of this month.
         """
         today = datetime.today()
-        first_day, last_day = monthrange(today.year, today.month)
-        from_dt = datetime(today.year, today.month, first_day)
+        _, last_day = monthrange(today.year, today.month)
+        from_dt = datetime(today.year, today.month, 1)
         to_dt = datetime(today.year, today.month, last_day)
         params = dict(self.params)
         params.update(


### PR DESCRIPTION
Somebody created bug in the past https://github.com/mandarons/icloudpy/issues/26. It missed steps to reproduce or a fix.

This PR describes how to reproduce and has code fix.

**The issue** is that calendar sync will fail on months that have Monday as 1st day of the month (e.g. 2024 April 1 is Monday).

Buggy code is:

```python
from calendar import monthrange
first_day, last_day = monthrange(today.year, today.month)
```

According to the [docs](https://www.w3resource.com/python/module/calendar/monthrange.php):

> The monthrange() method is used to get weekday of first day of the month and number of days in month

So in this code variable `first_day` can return `0` (for Monday) and this will crash `datetime()`.

**Before the fix**

```python
>>> from icloudpy import ICloudPyService
>>>
>>> api = ICloudPyService('usernae', 'password')
>>> api.validate_2fa_code(123456)
True
>>> api.calendar.events()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/remigijus/Work/gather/icloudpy/icloudpy/services/calendar.py", line 71, in events
    self.refresh_client(from_dt, to_dt)
  File "/Users/remigijus/Work/gather/icloudpy/icloudpy/services/calendar.py", line 51, in refresh_client
    from_dt = datetime(today.year, today.month, first_day)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: day is out of range for month
```

**After the fix**

```python
>>> from icloudpy import ICloudPyService
>>> api = ICloudPyService('usernae', 'password')
>>> api.calendar.events()
[{'tz': 'Floating', 'icon': 0, 'recurrenceException': False, 'title': 'Test', 'duration': 0, 'allDay': False, [..]]
```