### PR TITLE
Add captions as a photo field

### DIFF
--- a/icloudpy/services/photos.py
+++ b/icloudpy/services/photos.py
@@ -585,6 +585,7 @@ class PhotoAlbum:
                 "burstFlagsExt",
                 "burstId",
                 "captionEnc",
+                "extendedDescEnc",
                 "locationEnc",
                 "locationV2Enc",
                 "locationLatitude",


### PR DESCRIPTION
iOS 14 introduced captions to Photos. This PR adds the caption field to the list of requested fields.