### PR TITLE
Add "ImportedBy*" fields for photos

### DIFF
--- a/icloudpy/services/photos.py
+++ b/icloudpy/services/photos.py
@@ -602,6 +602,9 @@ class PhotoAlbum:
                 "itemId",
                 "position",
                 "isKeyAsset",
+                "importedByBundleIdentifierEnc",
+                "importedByDisplayNameEnc",
+                "importedBy"
             ],
             "zoneID": self._zone_id,
         }


### PR DESCRIPTION
Add 3 fields for photos that indicate the importer app
- `importedBy`: not sure, seems to be the classification of importer apps. (e.g. 3=apps, 8=snapshots)
- `importedByDisplayNameEnc`: The app name shown in webapp and the album,  encoded using base64.
- `importedByBundleIdentifierEnc`: Bundle Identifier, encoded using base64.