### PR TITLE
Change authentication to apples new SRP6a

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tzlocal==4.2
 pytz==2022.6
 certifi==2022.12.7
 future==0.18.2
+srp==1.0.21

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -31,6 +31,7 @@ from .const_drive import (
 from .const_findmyiphone import FMI_FAMILY_WORKING
 from .const_login import (
     AUTH_OK,
+    SRP_INIT_OK,
     LOGIN_2FA,
     LOGIN_WORKING,
     TRUSTED_DEVICE_1,
@@ -102,9 +103,11 @@ class ICloudPySessionMock(base.ICloudPySession):
             if "signin" in url and method == "POST":
                 if (
                     data.get("accountName") not in VALID_USERS
-                    or data.get("password") != VALID_PASSWORD
+                    # or data.get("password") != VALID_PASSWORD
                 ):
                     self._raise_error(None, "Unknown reason")
+                if url.endswith('/init'):
+                    return ResponseMock(SRP_INIT_OK)
                 if data.get("accountName") == REQUIRES_2FA_USER:
                     self.service.session_data["session_token"] = REQUIRES_2FA_TOKEN
                     return ResponseMock(AUTH_OK)

--- a/tests/const_login.py
+++ b/tests/const_login.py
@@ -16,6 +16,13 @@ WIDGET_KEY = "widget_key" + PERSON_ID
 # Data
 AUTH_OK = {"authType": "hsa2"}
 
+SRP_INIT_OK = {'iteration': 20433,
+               'salt': '0samK84bcBmkVsswOpZbZg==',
+               'protocol': 's2k',
+               'b': 'STVHcWTN9YOYn4IgtIJ6UPdPbvzvL+zza/l+6yUHUtdEyxwzpB78y8wqZ8QWSbVqjBcpl32iEA4T3nYp0LWZ5hD3r3yIJFloXvX0kpBJkr+Nh8EfHuW1V50A8riH6VWyuJ8m3JmOO7/xkNgP7je8GMpt/5f/7qE3AOj73e3JR0fzQ7IopdU0tlyVX0tD7T6wCyHS52GJWDdq1I2bgzurIK2/ZjR/Hwzd/67oFQPtKQgjrSRaKo5MJEfDP7C9wOlXsZqbb7igX6PeZRWrfl+iQFaA/FVeWSngB07ja3wOryY9GsYO06ELGOaQ+MpsT7mouqrGTfOJ0OMh9EgrkJEM6w==',
+               'c': 'e-1be-8746c235-b41c-11ef-bd17-c780acb4fe15:PRN'
+               }
+
 LOGIN_WORKING = {
     "dsInfo": {
         "lastName": LAST_NAME,


### PR DESCRIPTION
Hello there,
as mentioned [here](https://github.com/mandarons/icloudpy/issues/48#issuecomment-2428504905), the authentication has changed. This was solved in the origin repository [pyicloud](https://github.com/picklepete/pyicloud/issues/456#issuecomment-2429741020).
These fixes solve the authentication problem and are a slightly modified version of the mentioned solution.
