### PR TITLE
Remove Python 2 support

### DIFF
--- a/icloudpy/base.py
+++ b/icloudpy/base.py
@@ -14,7 +14,6 @@ from uuid import uuid1
 
 import srp
 from requests import Session
-from six import PY2
 
 from icloudpy.exceptions import (
     ICloudPy2SARequiredException,
@@ -689,10 +688,7 @@ class ICloudPyService:
         return f"iCloud API: {self.user.get('accountName')}"
 
     def __str__(self):
-        as_unicode = self.__unicode__()
-        if PY2:
-            return as_unicode.encode("utf-8", "ignore")
-        return as_unicode
+        return self.__unicode__()
 
     def __repr__(self):
         return f"<{str(self)}>"

--- a/icloudpy/services/account.py
+++ b/icloudpy/services/account.py
@@ -1,8 +1,6 @@
 """Account service."""
 from collections import OrderedDict
 
-from six import PY2
-
 from icloudpy.utils import underscore_to_camelcase
 
 
@@ -74,10 +72,7 @@ class AccountService:
         return f"{{devices: {len(self.devices)}, family: {len(self.family)}, storage: {storage_available} bytes free}}"
 
     def __str__(self):
-        as_unicode = self.__unicode__()
-        if PY2:
-            return as_unicode.encode("utf-8", "ignore")
-        return as_unicode
+        return self.__unicode__()
 
     def __repr__(self):
         return f"<{type(self).__name__}: {str(self)}>"
@@ -93,10 +88,7 @@ class AccountDevice(dict):
         return f"{{model: {self.model_display_name}, name: {self.name}}}"
 
     def __str__(self):
-        as_unicode = self.__unicode__()
-        if PY2:
-            return as_unicode.encode("utf-8", "ignore")
-        return as_unicode
+        return self.__unicode__()
 
     def __repr__(self):
         return f"<{type(self).__name__}: {str(self)}>"
@@ -210,10 +202,7 @@ class FamilyMember:
         )
 
     def __str__(self):
-        as_unicode = self.__unicode__()
-        if PY2:
-            return as_unicode.encode("utf-8", "ignore")
-        return as_unicode
+        return self.__unicode__()
 
     def __repr__(self):
         return f"<{type(self).__name__}: {str(self)}>"
@@ -249,10 +238,7 @@ class AccountStorageUsageForMedia:
         return f"{{key: {self.key}, usage: {self.usage_in_bytes} bytes}}"
 
     def __str__(self):
-        as_unicode = self.__unicode__()
-        if PY2:
-            return as_unicode.encode("utf-8", "ignore")
-        return as_unicode
+        return self.__unicode__()
 
     def __repr__(self):
         return f"<{type(self).__name__}: {str(self)}>"
@@ -326,10 +312,7 @@ class AccountStorageUsage:
         return f"{self.used_storage_in_percent}% used of {self.total_storage_in_bytes} bytes"
 
     def __str__(self):
-        as_unicode = self.__unicode__()
-        if PY2:
-            return as_unicode.encode("utf-8", "ignore")
-        return as_unicode
+        return self.__unicode__()
 
     def __repr__(self):
         return f"<{type(self).__name__}: {str(self)}>"
@@ -353,10 +336,7 @@ class AccountStorage:
         return f"{{usage: {self.usage}, usages_by_media: {self.usages_by_media}}}"
 
     def __str__(self):
-        as_unicode = self.__unicode__()
-        if PY2:
-            return as_unicode.encode("utf-8", "ignore")
-        return as_unicode
+        return self.__unicode__()
 
     def __repr__(self):
         return f"<{type(self).__name__}: {str(self)}>"

--- a/icloudpy/services/drive.py
+++ b/icloudpy/services/drive.py
@@ -8,7 +8,6 @@ from datetime import datetime, timedelta
 from re import search
 
 from requests import Response
-from six import PY2
 
 
 class DriveService:
@@ -363,10 +362,7 @@ class DriveNode:
         return f"{{type: {self.type}, name: {self.name}}}"
 
     def __str__(self):
-        as_unicode = self.__unicode__()
-        if PY2:  # pragma: no cover
-            return as_unicode.encode("utf-8", "ignore")
-        return as_unicode
+        return self.__unicode__()
 
     def __repr__(self):
         return f"<{type(self).__name__}: {str(self)}>"

--- a/icloudpy/services/findmyiphone.py
+++ b/icloudpy/services/findmyiphone.py
@@ -2,8 +2,6 @@
 
 import json
 
-from six import PY2
-
 from icloudpy.exceptions import ICloudPyNoDevicesException
 
 
@@ -80,10 +78,7 @@ class FindMyiPhoneServiceManager:
         return str(self._devices)
 
     def __str__(self):
-        as_unicode = self.__unicode__()
-        if PY2:
-            return as_unicode.encode("utf-8", "ignore")
-        return as_unicode
+        return self.__unicode__()
 
     def __repr__(self):
         return str(self)
@@ -210,10 +205,7 @@ class AppleDevice:
         return f"{display_name}: {name}"
 
     def __str__(self):
-        as_unicode = self.__unicode__()
-        if PY2:
-            return as_unicode.encode("utf-8", "ignore")
-        return as_unicode
+        return self.__unicode__()
 
     def __repr__(self):
         return f"<AppleDevice({self})>"

--- a/icloudpy/services/photos.py
+++ b/icloudpy/services/photos.py
@@ -9,7 +9,6 @@ from datetime import datetime
 from urllib.parse import urlencode  # pylint: disable=bad-option-value,relative-import
 
 from pytz import UTC
-from six import PY2
 
 # fmt: on
 from icloudpy.exceptions import ICloudPyServiceNotActivatedException
@@ -607,10 +606,7 @@ class PhotoAlbum:
         return self.title
 
     def __str__(self):
-        as_unicode = self.__unicode__()
-        if PY2:
-            return as_unicode.encode("utf-8", "ignore")
-        return as_unicode
+        return self.__unicode__()
 
     def __repr__(self):
         return f"<{type(self).__name__}: '{self}'>"

--- a/icloudpy/services/ubiquity.py
+++ b/icloudpy/services/ubiquity.py
@@ -1,8 +1,6 @@
 """File service."""
 from datetime import datetime
 
-from six import PY2
-
 
 class UbiquityService:
     """The 'Ubiquity' iCloud service."""
@@ -112,10 +110,7 @@ class UbiquityNode:
         return self.name
 
     def __str__(self):
-        as_unicode = self.__unicode__()
-        if PY2:
-            return as_unicode.encode("utf-8", "ignore")
-        return as_unicode
+        return self.__unicode__()
 
     def __repr__(self):
         return f"<{self.type.capitalize()}: '{self}'>"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,7 @@ requests==2.32.3
 keyring==25.6.0
 keyrings.alt==5.0.2
 click==8.1.8
-six==1.17.0
 srp==1.0.22
 tzlocal==5.2
 pytz==2024.2
 certifi==2024.12.14
-future==1.0.0

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -939,20 +939,6 @@ class TestSRPAuthenticationWithHeaders(TestCase):
         assert service.data is not None
 
 
-class TestPy2Compatibility(TestCase):
-    """Test Python 2 compatibility code paths."""
-
-    def test_str_with_py2_flag(self):
-        """Test __str__ method with PY2 flag."""
-        service = ICloudPyServiceMock(AUTHENTICATED_USER, VALID_PASSWORD)
-
-        # PY2 is imported from six and will be False in Python 3
-        # But the code path exists for backwards compatibility
-        str_repr = str(service)
-        assert isinstance(str_repr, str)
-        assert AUTHENTICATED_USER in str_repr
-
-
 class TestAuthenticationWithCredentialsService(TestCase):
     """Test _authenticate_with_credentials_service method."""
 

--- a/tests/test_drive.py
+++ b/tests/test_drive.py
@@ -770,27 +770,3 @@ class DriveHTTPErrorTests(TestCase):
 
         # Restore original
         self.service.session.request = original_request
-
-
-class DrivePython2CompatTests(TestCase):
-    """Test Python 2 compatibility paths.
-
-    Note: Line 368 in drive.py (PY2 encode path) is marked with pragma: no cover
-    because it's unreachable in Python 3.8+ which is the minimum supported version.
-    This is legacy code from when the project supported Python 2.
-    """
-
-    def setUp(self):
-        """Set up test."""
-        self.service = ICloudPyServiceMock(AUTHENTICATED_USER, VALID_PASSWORD, None, True, CLIENT_ID)
-        self.drive = self.service.drive
-
-    def test_drive_node_str_python3_path(self):
-        """Test __str__ method Python 3 code path."""
-        file = self.drive["iCloudPy"]["Test"]["Scanned document 1.pdf"]
-
-        # In Python 3, __str__ returns unicode string directly
-        result = str(file)
-        assert result is not None
-        assert "file" in result
-        assert isinstance(result, str)


### PR DESCRIPTION
## Summary
This PR removes all Python 2 specific code from the iCloudPy library, as Python 2 is no longer supported.

## Changes Made
- ✅ Removed `six` and `future` dependencies from `requirements.txt`
- ✅ Removed `from six import PY2` imports from all service files:
  - `icloudpy/base.py`
  - `icloudpy/services/account.py`
  - `icloudpy/services/drive.py`
  - `icloudpy/services/findmyiphone.py`
  - `icloudpy/services/photos.py`
  - `icloudpy/services/ubiquity.py`
- ✅ Simplified `__str__` methods to return `__unicode__()` directly without PY2 encoding checks
- ✅ Removed PY2 compatibility test classes:
  - `DrivePython2CompatTests` in `tests/test_drive.py`
  - `TestPy2Compatibility` in `tests/test_auth.py`

## Testing
All 199 tests pass successfully with 78.77% coverage (exceeds the 78% requirement).

```
==================== 199 passed, 1 warning in 5.04s ====================
```

## Impact
This is a breaking change only for users still running Python 2, which is already unsupported as per `setup.py` (requires Python >=3.8).

No functional changes to the library - all existing Python 3 functionality remains intact.