### PR TITLE
feat: add support for libraries that are shared with the user

### DIFF
--- a/icloudpy/base.py
+++ b/icloudpy/base.py
@@ -28,8 +28,8 @@ from icloudpy.services import (
     DriveService,
     FindMyiPhoneServiceManager,
     PhotosService,
-    SharedPhotosService,
     RemindersService,
+    SharedPhotosService,
 )
 from icloudpy.utils import get_password_from_keyring
 

--- a/icloudpy/base.py
+++ b/icloudpy/base.py
@@ -28,6 +28,7 @@ from icloudpy.services import (
     DriveService,
     FindMyiPhoneServiceManager,
     PhotosService,
+    SharedPhotosService,
     RemindersService,
 )
 from icloudpy.utils import get_password_from_keyring
@@ -641,6 +642,14 @@ class ICloudPyService:
             service_root = self._get_webservice_url("ckdatabasews")
             self._photos = PhotosService(service_root, self.session, self.params)
         return self._photos
+
+    @property
+    def shared_photos(self):
+        """Gets the Shared 'Photo' service."""
+        if not self._photos:
+            service_root = self._get_webservice_url("ckdatabasews")
+            self._shared_photos = SharedPhotosService(service_root, self.session, self.params)
+        return self._shared_photos
 
     @property
     def calendar(self):

--- a/icloudpy/base.py
+++ b/icloudpy/base.py
@@ -688,7 +688,7 @@ class ICloudPyService:
     @property
     def shared_photos(self):
         """Gets the Shared 'Photo' service."""
-        if not self._photos:
+        if not self._shared_photos:
             service_root = self._get_webservice_url("ckdatabasews")
             self._shared_photos = SharedPhotosService(service_root, self.session, self.params)
         return self._shared_photos

--- a/icloudpy/services/__init__.py
+++ b/icloudpy/services/__init__.py
@@ -8,7 +8,7 @@ from icloudpy.services.drive import DriveService
 from icloudpy.services.findmyiphone import (
     FindMyiPhoneServiceManager,
 )
-from icloudpy.services.photos import PhotosService
+from icloudpy.services.photos import ( PhotosService, SharedPhotosService )
 from icloudpy.services.reminders import (
     RemindersService,
 )

--- a/icloudpy/services/__init__.py
+++ b/icloudpy/services/__init__.py
@@ -8,7 +8,7 @@ from icloudpy.services.drive import DriveService
 from icloudpy.services.findmyiphone import (
     FindMyiPhoneServiceManager,
 )
-from icloudpy.services.photos import ( PhotosService, SharedPhotosService )
+from icloudpy.services.photos import PhotosService, SharedPhotosService
 from icloudpy.services.reminders import (
     RemindersService,
 )

--- a/icloudpy/services/photos.py
+++ b/icloudpy/services/photos.py
@@ -295,7 +295,6 @@ class SharedPhotosService(PhotoLibrary):
         self._photo_assets = {}
 
         try:
-            # url = f"{self._service_endpoint}/zones/list"
             url = f"{self._service_root}/database/1/com.apple.photos.cloud/production/shared/zones/list"
             request = self.session.post(
                 url,

--- a/icloudpy/services/photos.py
+++ b/icloudpy/services/photos.py
@@ -291,7 +291,6 @@ class SharedPhotosService(PhotoLibrary):
 
         self._service_endpoint = f"{self._service_root}/database/1/com.apple.photos.cloud/production/shared"
 
-        self._libraries = None
 
         self._photo_assets = {}
 

--- a/icloudpy/services/photos.py
+++ b/icloudpy/services/photos.py
@@ -275,9 +275,11 @@ class PhotosService(PhotoLibrary):
         return self._libraries
 
 class SharedPhotosService(PhotoLibrary):
-    """The 'Photos' iCloud service.
+    """The 'Shared Photos' iCloud service.
 
-    This also acts as the shared library if I am not the owner of the library.
+    Provides access to shared photo libraries, such as shared albums or libraries
+    that the user does not own. This is distinct from the regular PhotosService,
+    which provides access to the user's primary photo library.
     """
 
     def __init__(self, service_root, session, params):


### PR DESCRIPTION
This PR tries to address issue https://github.com/mandarons/icloudpy/issues/115.

I looked at the current structure of the Photos service. From my understanding, the way that the code is structured at the moment is such that `PhotosService` not only acts as the 'Photos' iCloud service, but behaves like the user's primary library. In doing so, the assumption is that this service is tied to a specific API end-point specified in init. However, the libraries that are shared with me are available on a different end-point.

My initial hope was to change the service so that I could do something like `api.photos.libraries` and obtain the list of all my libraries, the ones I own and the ones I am shared with. However, I could not find a way to achieve this while reusing as much of the current code as possible and also maintaining compatibility without introducing braking changes.
So here are my 2 cents: I am not sure why `PhotosService` inherit from `PhotosLibrary`, it feel conceptually wrong. I do understand that it might make it nice to have `PhotosService` behave like the user's primary library, but since this also ties the service to a specific end-point I really could not find a way to work around it.

This PR is the best solution that I could think of while trying to follow the current philosophy of one service tied to one end-point: a new service, `SharedPhotosService`, which essentially behaves like `PhotosService` but is dedicated to the library shared with the user.

**Note**: unlike for queries to the private library, queries to the shared library need to have the `ownerRecordName` specified, which means that it is not possible to initialize `SharedPhotosService` the same way as you would with `PhotosService` which does not require `ownerRecordName`.

Let me know what you think of this solution, I can also add some pytests to cover it and update the README to clarify the difference in the two services.