### PR TITLE
fix: trigger 2FA push notification on iOS 26.4+ (resolves the auth stall in mandarons/icloud-docker#426)

### DIFF
--- a/icloudpy/base.py
+++ b/icloudpy/base.py
@@ -588,6 +588,42 @@ class ICloudPyService:
             LOGGER.debug("Failed to trigger 2FA push notification.")
             return False
 
+    def trigger_2fa_push_notification(self):
+        """Asks Apple to push a 2FA verification code to trusted devices.
+
+        Apple's auth flow (changed around iOS 26 / early 2026) requires a PUT
+        to ``/verify/trusteddevice/securitycode`` (no body) to initiate code
+        delivery to trusted devices. Without this step, the user is prompted
+        for a code but no code is ever pushed to any device — auth stalls.
+
+        Callers should invoke this method before prompting the user for the
+        2FA code (i.e., right after ``requires_2fa`` returns True). Failure
+        is non-fatal — a code may still arrive via SMS or another path.
+
+        See: https://github.com/mandarons/icloud-docker/issues/426
+        Ported from icloud_photos_downloader PR #1335.
+
+        :returns: True if the push request succeeded, False otherwise.
+        """
+        headers = self._get_auth_headers({"Accept": "application/json"})
+
+        if self.session_data.get("scnt"):
+            headers["scnt"] = self.session_data.get("scnt")
+
+        if self.session_data.get("session_id"):
+            headers["X-Apple-ID-Session-Id"] = self.session_data.get("session_id")
+
+        try:
+            self.session.put(
+                f"{self.auth_endpoint}/verify/trusteddevice/securitycode",
+                headers=headers,
+            )
+            LOGGER.debug("2FA push notification triggered.")
+            return True
+        except Exception as error:  # network, SSL, or Apple API errors are all non-fatal here
+            LOGGER.debug("Failed to trigger 2FA push notification: %s", error)
+            return False
+
     def validate_2fa_code(self, code):
         """Verifies a verification code received via Apple's 2FA system (HSA2)."""
         data = {"securityCode": {"code": code}}

--- a/icloudpy/base.py
+++ b/icloudpy/base.py
@@ -578,10 +578,16 @@ class ICloudPyService:
             headers["X-Apple-ID-Session-Id"] = self.session_data.get("session_id")
 
         try:
-            self.session.put(
+            response = self.session.put(
                 f"{self.auth_endpoint}/verify/trusteddevice/securitycode",
                 headers=headers,
             )
+            if not (200 <= response.status_code < 300):
+                LOGGER.debug(
+                    "2FA push notification trigger returned status %s",
+                    response.status_code,
+                )
+                return False
             LOGGER.debug("2FA push notification triggered.")
             return True
         except Exception as error:  # network, SSL, or Apple API errors are all non-fatal here

--- a/icloudpy/base.py
+++ b/icloudpy/base.py
@@ -552,6 +552,42 @@ class ICloudPyService:
 
         return not self.requires_2sa
 
+    def trigger_2fa_push_notification(self):
+        """Asks Apple to push a 2FA verification code to trusted devices.
+
+        Apple's auth flow (changed around iOS 26 / early 2026) requires a PUT
+        to ``/verify/trusteddevice/securitycode`` (no body) to initiate code
+        delivery to trusted devices. Without this step, the user is prompted
+        for a code but no code is ever pushed to any device — auth stalls.
+
+        Callers should invoke this method before prompting the user for the
+        2FA code (i.e., right after ``requires_2fa`` returns True). Failure
+        is non-fatal — a code may still arrive via SMS or another path.
+
+        See: https://github.com/mandarons/icloud-docker/issues/426
+        Ported from icloud_photos_downloader PR #1335.
+
+        :returns: True if the push request succeeded, False otherwise.
+        """
+        headers = self._get_auth_headers({"Accept": "application/json"})
+
+        if self.session_data.get("scnt"):
+            headers["scnt"] = self.session_data.get("scnt")
+
+        if self.session_data.get("session_id"):
+            headers["X-Apple-ID-Session-Id"] = self.session_data.get("session_id")
+
+        try:
+            self.session.put(
+                f"{self.auth_endpoint}/verify/trusteddevice/securitycode",
+                headers=headers,
+            )
+            LOGGER.debug("2FA push notification triggered.")
+            return True
+        except ICloudPyAPIResponseException:
+            LOGGER.debug("Failed to trigger 2FA push notification.")
+            return False
+
     def validate_2fa_code(self, code):
         """Verifies a verification code received via Apple's 2FA system (HSA2)."""
         data = {"securityCode": {"code": code}}

--- a/icloudpy/base.py
+++ b/icloudpy/base.py
@@ -584,42 +584,6 @@ class ICloudPyService:
             )
             LOGGER.debug("2FA push notification triggered.")
             return True
-        except ICloudPyAPIResponseException:
-            LOGGER.debug("Failed to trigger 2FA push notification.")
-            return False
-
-    def trigger_2fa_push_notification(self):
-        """Asks Apple to push a 2FA verification code to trusted devices.
-
-        Apple's auth flow (changed around iOS 26 / early 2026) requires a PUT
-        to ``/verify/trusteddevice/securitycode`` (no body) to initiate code
-        delivery to trusted devices. Without this step, the user is prompted
-        for a code but no code is ever pushed to any device — auth stalls.
-
-        Callers should invoke this method before prompting the user for the
-        2FA code (i.e., right after ``requires_2fa`` returns True). Failure
-        is non-fatal — a code may still arrive via SMS or another path.
-
-        See: https://github.com/mandarons/icloud-docker/issues/426
-        Ported from icloud_photos_downloader PR #1335.
-
-        :returns: True if the push request succeeded, False otherwise.
-        """
-        headers = self._get_auth_headers({"Accept": "application/json"})
-
-        if self.session_data.get("scnt"):
-            headers["scnt"] = self.session_data.get("scnt")
-
-        if self.session_data.get("session_id"):
-            headers["X-Apple-ID-Session-Id"] = self.session_data.get("session_id")
-
-        try:
-            self.session.put(
-                f"{self.auth_endpoint}/verify/trusteddevice/securitycode",
-                headers=headers,
-            )
-            LOGGER.debug("2FA push notification triggered.")
-            return True
         except Exception as error:  # network, SSL, or Apple API errors are all non-fatal here
             LOGGER.debug("Failed to trigger 2FA push notification: %s", error)
             return False

--- a/icloudpy/cmdline.py
+++ b/icloudpy/cmdline.py
@@ -238,7 +238,7 @@ def main(args=None):
                 if not api.trigger_2fa_push_notification():
                     print(
                         "(Could not trigger push notification — "
-                        "a code may still arrive via SMS or another path.)"
+                        "a code may still arrive via SMS or another path.)",
                     )
 
                 # fmt: off

--- a/icloudpy/cmdline.py
+++ b/icloudpy/cmdline.py
@@ -232,6 +232,15 @@ def main(args=None):
                 utils.store_password_in_keyring(username, password)
 
             if api.requires_2fa:
+                # Apple's auth flow (2026+) requires an explicit PUT to push
+                # the code to trusted devices. Without this, the user is
+                # prompted but no code is ever delivered.
+                if not api.trigger_2fa_push_notification():
+                    print(
+                        "(Could not trigger push notification — "
+                        "a code may still arrive via SMS or another path.)"
+                    )
+
                 # fmt: off
                 print(
                     "\nTwo-step authentication required.",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -158,6 +158,11 @@ class ICloudPySessionMock(base.ICloudPySession):
                 self.service.session_data["session_token"] = VALID_TOKEN
                 return ResponseMock("", status_code=204)
 
+            if "securitycode" in url and method == "PUT":
+                # PUT (no body) triggers Apple's push notification flow for 2FA.
+                # Added 2026+ via icloudpy fix/ios-26.4-auth.
+                return ResponseMock("", status_code=204)
+
             if "trust" in url and method == "GET":
                 return ResponseMock("", status_code=204)
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -156,8 +156,6 @@ class TestTwoFactorAuthentication(TestCase):
 
     def test_trigger_2fa_push_notification_includes_session_headers(self):
         """trigger_2fa_push_notification must forward scnt + session_id headers."""
-        from unittest.mock import patch
-
         service = ICloudPyServiceMock(REQUIRES_2FA_USER, VALID_PASSWORD)
         service.session_data["scnt"] = "scnt-value"
         service.session_data["session_id"] = "session-id-value"
@@ -174,12 +172,8 @@ class TestTwoFactorAuthentication(TestCase):
         assert call_headers["scnt"] == "scnt-value"
         assert call_headers["X-Apple-ID-Session-Id"] == "session-id-value"
 
-    def test_trigger_2fa_push_notification_failure_is_non_fatal(self):
-        """Failure to trigger push must return False, not raise."""
-        from unittest.mock import patch
-
-        from icloudpy.exceptions import ICloudPyAPIResponseException
-
+    def test_trigger_2fa_push_notification_api_failure_is_non_fatal(self):
+        """Apple API errors must return False, not raise."""
         service = ICloudPyServiceMock(REQUIRES_2FA_USER, VALID_PASSWORD)
 
         with patch.object(service.session, "put") as fake_put:
@@ -187,6 +181,27 @@ class TestTwoFactorAuthentication(TestCase):
             result = service.trigger_2fa_push_notification()
 
         assert result is False
+
+    def test_trigger_2fa_push_notification_network_failure_is_non_fatal(self):
+        """Network/transport errors (timeout, SSL, connection) must return False, not raise.
+
+        The docstring promises non-fatal behavior — the implementation must
+        deliver it for all exception types, not only Apple API errors.
+        """
+        import requests
+
+        service = ICloudPyServiceMock(REQUIRES_2FA_USER, VALID_PASSWORD)
+
+        for exc in (
+            requests.exceptions.ConnectionError("network down"),
+            requests.exceptions.Timeout("too slow"),
+            requests.exceptions.SSLError("cert error"),
+        ):
+            with patch.object(service.session, "put") as fake_put:
+                fake_put.side_effect = exc
+                # Must not raise
+                result = service.trigger_2fa_push_notification()
+            assert result is False, f"network exception {type(exc).__name__} should return False"
 
 
 class TestTwoStepAuthentication(TestCase):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -565,7 +565,7 @@ class TestErrorCodeHandling(TestCase):
 
         with pytest.raises(ICloudPyServiceNotActivatedException) as exc_info:
             service.session._raise_error(
-                "AUTHENTICATION_FAILED", "Authentication failed"
+                "AUTHENTICATION_FAILED", "Authentication failed",
             )
 
         assert "manually finish setting up" in str(exc_info.value)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -15,7 +15,7 @@ from icloudpy.exceptions import (
     ICloudPyServiceNotActivatedException,
 )
 
-from . import ICloudPyServiceMock
+from . import ICloudPyServiceMock, ResponseMock
 from .const import (
     AUTHENTICATED_USER,
     REQUIRES_2FA_USER,
@@ -144,6 +144,48 @@ class TestTwoFactorAuthentication(TestCase):
         service = ICloudPyServiceMock(REQUIRES_2FA_USER, VALID_PASSWORD)
         # The code in base.py catches error code -21669 and returns False
         result = service.validate_2fa_code("000001")  # Wrong code
+        assert result is False
+
+    def test_trigger_2fa_push_notification_success(self):
+        """trigger_2fa_push_notification PUTs to the securitycode endpoint."""
+        service = ICloudPyServiceMock(REQUIRES_2FA_USER, VALID_PASSWORD)
+        # Mock returns 204 for PUT to /verify/trusteddevice/securitycode
+        # See tests/__init__.py mock dispatch for the PUT branch.
+        result = service.trigger_2fa_push_notification()
+        assert result is True
+
+    def test_trigger_2fa_push_notification_includes_session_headers(self):
+        """trigger_2fa_push_notification must forward scnt + session_id headers."""
+        from unittest.mock import patch
+
+        service = ICloudPyServiceMock(REQUIRES_2FA_USER, VALID_PASSWORD)
+        service.session_data["scnt"] = "scnt-value"
+        service.session_data["session_id"] = "session-id-value"
+
+        with patch.object(service.session, "put") as fake_put:
+            fake_put.return_value = ResponseMock("", status_code=204)
+            result = service.trigger_2fa_push_notification()
+
+        assert result is True
+        fake_put.assert_called_once()
+        call_url = fake_put.call_args.args[0]
+        call_headers = fake_put.call_args.kwargs["headers"]
+        assert call_url.endswith("/verify/trusteddevice/securitycode")
+        assert call_headers["scnt"] == "scnt-value"
+        assert call_headers["X-Apple-ID-Session-Id"] == "session-id-value"
+
+    def test_trigger_2fa_push_notification_failure_is_non_fatal(self):
+        """Failure to trigger push must return False, not raise."""
+        from unittest.mock import patch
+
+        from icloudpy.exceptions import ICloudPyAPIResponseException
+
+        service = ICloudPyServiceMock(REQUIRES_2FA_USER, VALID_PASSWORD)
+
+        with patch.object(service.session, "put") as fake_put:
+            fake_put.side_effect = ICloudPyAPIResponseException("Bad gateway")
+            result = service.trigger_2fa_push_notification()
+
         assert result is False
 
 
@@ -507,7 +549,9 @@ class TestErrorCodeHandling(TestCase):
         service = ICloudPyServiceMock(AUTHENTICATED_USER, VALID_PASSWORD)
 
         with pytest.raises(ICloudPyServiceNotActivatedException) as exc_info:
-            service.session._raise_error("AUTHENTICATION_FAILED", "Authentication failed")
+            service.session._raise_error(
+                "AUTHENTICATION_FAILED", "Authentication failed"
+            )
 
         assert "manually finish setting up" in str(exc_info.value)
 


### PR DESCRIPTION
## Summary
Restores 2FA on iOS 26.4+ trusted devices.

Since iOS 26.4 (Feb 2026), `validate_2fa_code()` is unreachable in practice
because the 6-digit code never arrives on any trusted device — Apple changed
the flow to require an explicit `PUT /verify/trusteddevice/securitycode`
(no body) to initiate code delivery. Without it, callers see
"Please enter validation code" and wait forever.

This PR adds `ICloudPyService.trigger_2fa_push_notification()` — the explicit
PUT — and wires it into the bundled `icloudpy` CLI so it works out of the
box. The bundled `cmdline.py` calls it right after `requires_2fa` returns
True and before prompting the user for the code.

Other library consumers (mandarons/icloud-docker, etc.) need only add a
single `api.trigger_2fa_push_notification()` call before their own
prompt-for-code logic to inherit the fix.

Refs: mandarons/icloud-docker#426

## Validation
- 4 new unit tests in `tests/test_auth.py`:
  - `test_trigger_2fa_push_notification_success` (happy path via mock)
  - `test_trigger_2fa_push_notification_includes_session_headers` (scnt + session_id forwarding)
  - `test_trigger_2fa_push_notification_api_failure_is_non_fatal` (ICloudPyAPIResponseException → False)
  - `test_trigger_2fa_push_notification_network_failure_is_non_fatal` (ConnectionError / Timeout / SSLError → False)
- Existing tests pass; only the pre-existing `test_storage` ordering issue
  remains, unrelated to this change.
- **Live-validated** against a real Apple ID with an iOS 26.x trusted device:
  push notification arrived, code accepted, Photos + Drive services reachable.

## Approach
Ported from icloud-photos-downloader/icloud_photos_downloader#1335. That fix
has been validated in the `boredazfcuk/docker-icloudpd` community since
2026-05-04 and is the known-working solution. This PR adapts the same
approach to icloudpy's smaller, simpler API surface.

## Notes
- Failure to trigger push is non-fatal (returns False — both `ICloudPyAPIResponseException`
  AND network-level exceptions like `Timeout`/`ConnectionError`/`SSLError`).
  A code may still arrive via SMS or another path, and callers can fall
  through to the `validate_2fa_code` call regardless.
- The SMS-fallback piece of upstream PR #1335 (`pyicloud_ipd/sms.py` changes)
  is not ported here — icloudpy doesn't have an equivalent SMS parser. Its
  2SA flow uses `validate_verification_code` via `/listDevices`, which is a
  separate code path that hasn't been affected by the iOS 26.4 change.
