### PR TITLE
feat: surface Live Photo .mov pair via versions (enables fixing mandarons/icloud-docker#199)

### DIFF
--- a/icloudpy/services/photos.py
+++ b/icloudpy/services/photos.py
@@ -622,6 +622,32 @@ class PhotoAsset:
 
         self._versions = None
 
+    # Apple Uniform Type Identifiers (UTIs) for known iCloud photo/video assets.
+    # Mirrors the table in icloud_photos_downloader's pyicloud_ipd.services.photos.
+    # Anything not listed here falls back to the filename-extension heuristic in
+    # `item_type` below.
+    ITEM_TYPES = {
+        "public.heic": "image",
+        "public.heif": "image",
+        "public.jpeg": "image",
+        "public.png": "image",
+        "public.tiff": "image",
+        "com.adobe.raw-image": "image",
+        "com.canon.cr2-raw-image": "image",
+        "com.canon.cr3-raw-image": "image",
+        "com.canon.crw-raw-image": "image",
+        "com.fuji.raw-image": "image",
+        "com.nikon.nrw-raw-image": "image",
+        "com.nikon.raw-image": "image",
+        "com.olympus.or-raw-image": "image",
+        "com.olympus.raw-image": "image",
+        "com.panasonic.rw2-raw-image": "image",
+        "com.pentax.raw-image": "image",
+        "com.sony.arw-raw-image": "image",
+        "com.apple.quicktime-movie": "movie",
+        "public.mpeg-4": "movie",
+    }
+
     PHOTO_VERSION_LOOKUP = {
         "full": "resJPEGFull",
         "large": "resJPEGLarge",
@@ -630,6 +656,15 @@ class PhotoAsset:
         "sidecar": "resSidecar",
         "original": "resOriginal",
         "original_alt": "resOriginalAlt",
+        # Live Photo video components — present alongside the still image for
+        # Live Photos. The CloudKit master_record carries `resOriginalVidCompl*`
+        # (the original .mov), and may also expose `resVidMed*` / `resVidSmall*`
+        # for smaller variants. If the asset is a regular still photo, these
+        # keys are silently skipped by `versions` since the underlying fields
+        # are absent.
+        "live_video_original": "resOriginalVidCompl",
+        "live_video_medium": "resVidMed",
+        "live_video_thumb": "resVidSmall",
     }
 
     VIDEO_VERSION_LOOKUP = {
@@ -694,11 +729,53 @@ class PhotoAsset:
         )
 
     @property
+    def item_type(self):
+        """Returns 'image' or 'movie' for this asset.
+
+        Reads the CloudKit ``itemType`` field (Apple UTI string) and maps it
+        via ``ITEM_TYPES``. Falls back to a filename-extension heuristic when
+        the UTI is missing or unrecognised — that path catches GoPro footage
+        and a handful of camera-RAW formats that Apple has not assigned a
+        canonical UTI to.
+
+        Returns ``None`` only when both the UTI is missing AND no filename is
+        available (rare — usually a CloudKit record with no master payload).
+        """
+        fields = self._master_record["fields"]
+        uti = fields.get("itemType", {}).get("value")
+        if uti in self.ITEM_TYPES:
+            return self.ITEM_TYPES[uti]
+
+        # Extension-based fallback. Mirrors pyicloud_ipd's heuristic.
+        filename = self.filename
+        if filename:
+            lower = filename.lower()
+            if lower.endswith((".heic", ".heif", ".png", ".jpg", ".jpeg", ".tif", ".tiff")):
+                return "image"
+            if lower.endswith((".mov", ".mp4", ".m4v", ".avi", ".3gp")):
+                return "movie"
+        return None
+
+    @property
     def versions(self):
-        """Gets the photo versions."""
+        """Gets the photo versions.
+
+        For ``item_type == "movie"`` returns the video versions
+        (``VIDEO_VERSION_LOOKUP``). For everything else returns the image
+        versions (``PHOTO_VERSION_LOOKUP``) — which includes Live Photo video
+        keys (``live_video_original`` / ``live_video_medium`` /
+        ``live_video_thumb``) when the underlying CloudKit fields are present.
+
+        Backward compatibility: callers that previously received only photo
+        versions for still images and only video versions for movies still see
+        those keys. Live Photo callers gain new ``live_video_*`` keys that
+        were previously inaccessible — earlier icloudpy versions misclassified
+        Live Photos as movies (via the ``resVidSmallRes`` presence heuristic)
+        and dropped the still image entirely.
+        """
         if not self._versions:
             self._versions = {}
-            if "resVidSmallRes" in self._master_record["fields"]:
+            if self.item_type == "movie":
                 typed_version_lookup = self.VIDEO_VERSION_LOOKUP
             else:
                 typed_version_lookup = self.PHOTO_VERSION_LOOKUP

--- a/tests/test_photos.py
+++ b/tests/test_photos.py
@@ -941,3 +941,164 @@ class PhotoAssetMissingFilenameTests(unittest.TestCase):
         assert len(dims) == 2
         assert dims[0] == 1920  # width
         assert dims[1] == 1080  # height
+
+
+# ─── Live Photo / item_type tests ─────────────────────────────────────────
+# Added 2026-05-27 as part of feat/live-photos.
+
+import base64 as _b64
+
+from icloudpy.services.photos import PhotoAsset
+
+
+def _b64name(name):
+    return _b64.b64encode(name.encode()).decode()
+
+
+def _photo_field(prefix, *, size=12345, url=None, file_type="public.heic", width=4032, height=3024):
+    """Build the CloudKit master_record fields for one asset version prefix."""
+    return {
+        f"{prefix}Width": {"value": width},
+        f"{prefix}Height": {"value": height},
+        f"{prefix}FileType": {"value": file_type},
+        f"{prefix}Res": {
+            "value": {
+                "size": size,
+                "downloadURL": url or f"https://example.invalid/{prefix}",
+                "fileChecksum": f"sum-{prefix}",
+            }
+        },
+    }
+
+
+def _make_master(filename, item_type_uti, *field_blocks):
+    fields = {"filenameEnc": {"value": _b64name(filename)}}
+    if item_type_uti is not None:
+        fields["itemType"] = {"value": item_type_uti}
+    for block in field_blocks:
+        fields.update(block)
+    return {"recordName": "test-record", "fields": fields}
+
+
+def _make_asset_record():
+    return {"fields": {"assetDate": {"value": 1700000000000}, "addedDate": {"value": 1700000000000}}}
+
+
+class TestItemTypeDetection(unittest.TestCase):
+    """item_type property — UTI lookup + extension fallback."""
+
+    def test_heic_uti_returns_image(self):
+        master = _make_master("photo.heic", "public.heic", _photo_field("resOriginal"))
+        asset = PhotoAsset(service=None, master_record=master, asset_record=_make_asset_record())
+        assert asset.item_type == "image"
+
+    def test_jpeg_uti_returns_image(self):
+        master = _make_master("photo.jpg", "public.jpeg", _photo_field("resOriginal", file_type="public.jpeg"))
+        asset = PhotoAsset(service=None, master_record=master, asset_record=_make_asset_record())
+        assert asset.item_type == "image"
+
+    def test_quicktime_uti_returns_movie(self):
+        master = _make_master("clip.mov", "com.apple.quicktime-movie",
+                              _photo_field("resOriginal", file_type="com.apple.quicktime-movie"))
+        asset = PhotoAsset(service=None, master_record=master, asset_record=_make_asset_record())
+        assert asset.item_type == "movie"
+
+    def test_canon_raw_uti_returns_image(self):
+        master = _make_master("raw.cr3", "com.canon.cr3-raw-image", _photo_field("resOriginal"))
+        asset = PhotoAsset(service=None, master_record=master, asset_record=_make_asset_record())
+        assert asset.item_type == "image"
+
+    def test_missing_uti_with_heic_extension_returns_image(self):
+        master = _make_master("photo.HEIC", None, _photo_field("resOriginal"))
+        asset = PhotoAsset(service=None, master_record=master, asset_record=_make_asset_record())
+        assert asset.item_type == "image"
+
+    def test_missing_uti_with_mov_extension_returns_movie(self):
+        master = _make_master("clip.MOV", None, _photo_field("resOriginal"))
+        asset = PhotoAsset(service=None, master_record=master, asset_record=_make_asset_record())
+        assert asset.item_type == "movie"
+
+    def test_no_uti_no_filename_returns_none(self):
+        master = {"recordName": "r", "fields": _photo_field("resOriginal")}
+        asset = PhotoAsset(service=None, master_record=master, asset_record=_make_asset_record())
+        # filename property raises KeyError → returns None; item_type sees None and falls through
+        assert asset.item_type is None
+
+    def test_unknown_uti_with_jpg_extension_returns_image(self):
+        master = _make_master("photo.jpg", "public.fake-format", _photo_field("resOriginal"))
+        asset = PhotoAsset(service=None, master_record=master, asset_record=_make_asset_record())
+        assert asset.item_type == "image"
+
+
+class TestLivePhotoVersions(unittest.TestCase):
+    """Live Photo asset surfaces BOTH still and .mov versions."""
+
+    def _live_photo_master(self):
+        """A Live Photo has both photo fields AND the live-video fields in master_record."""
+        return _make_master(
+            "IMG_1234.HEIC",
+            "public.heic",
+            _photo_field("resOriginal", size=2_400_000, url="https://example.invalid/heic"),
+            _photo_field("resJPEGMed", size=300_000, url="https://example.invalid/jpeg-med", file_type="public.jpeg"),
+            _photo_field("resOriginalVidCompl", size=1_800_000,
+                         url="https://example.invalid/live.mov",
+                         file_type="com.apple.quicktime-movie"),
+            _photo_field("resVidMed", size=900_000,
+                         url="https://example.invalid/live-med.mov",
+                         file_type="com.apple.quicktime-movie"),
+            _photo_field("resVidSmall", size=200_000,
+                         url="https://example.invalid/live-thumb.mov",
+                         file_type="com.apple.quicktime-movie"),
+        )
+
+    def test_live_photo_classified_as_image(self):
+        asset = PhotoAsset(service=None, master_record=self._live_photo_master(),
+                           asset_record=_make_asset_record())
+        assert asset.item_type == "image"
+
+    def test_live_photo_exposes_still_version(self):
+        asset = PhotoAsset(service=None, master_record=self._live_photo_master(),
+                           asset_record=_make_asset_record())
+        assert "original" in asset.versions
+        assert asset.versions["original"]["url"] == "https://example.invalid/heic"
+        assert asset.versions["original"]["size"] == 2_400_000
+
+    def test_live_photo_exposes_live_video_versions(self):
+        asset = PhotoAsset(service=None, master_record=self._live_photo_master(),
+                           asset_record=_make_asset_record())
+        assert "live_video_original" in asset.versions
+        assert asset.versions["live_video_original"]["url"] == "https://example.invalid/live.mov"
+        assert asset.versions["live_video_original"]["type"] == "com.apple.quicktime-movie"
+        assert "live_video_medium" in asset.versions
+        assert "live_video_thumb" in asset.versions
+
+    def test_plain_photo_has_no_live_video_versions(self):
+        """A still photo with no Live Photo .mov in CloudKit must not surface live_video_* keys."""
+        master = _make_master("plain.heic", "public.heic", _photo_field("resOriginal"))
+        asset = PhotoAsset(service=None, master_record=master, asset_record=_make_asset_record())
+        assert "original" in asset.versions
+        assert "live_video_original" not in asset.versions
+        assert "live_video_medium" not in asset.versions
+        assert "live_video_thumb" not in asset.versions
+
+    def test_regular_video_uses_video_lookup(self):
+        """Movies (item_type=movie) must use VIDEO_VERSION_LOOKUP, not PHOTO_VERSION_LOOKUP."""
+        master = _make_master(
+            "clip.MOV",
+            "com.apple.quicktime-movie",
+            _photo_field("resOriginal", size=10_000_000,
+                         url="https://example.invalid/orig.mov",
+                         file_type="com.apple.quicktime-movie"),
+            _photo_field("resVidMed", size=2_000_000,
+                         url="https://example.invalid/med.mov",
+                         file_type="com.apple.quicktime-movie"),
+            _photo_field("resVidSmall", size=500_000,
+                         url="https://example.invalid/small.mov",
+                         file_type="com.apple.quicktime-movie"),
+        )
+        asset = PhotoAsset(service=None, master_record=master, asset_record=_make_asset_record())
+        assert asset.item_type == "movie"
+        # video lookup keys are 'medium' / 'thumb' / 'original', NOT 'live_video_*'
+        assert "medium" in asset.versions
+        assert "thumb" in asset.versions
+        assert "live_video_original" not in asset.versions

--- a/tests/test_photos.py
+++ b/tests/test_photos.py
@@ -966,7 +966,7 @@ def _photo_field(prefix, *, size=12345, url=None, file_type="public.heic", width
                 "size": size,
                 "downloadURL": url or f"https://example.invalid/{prefix}",
                 "fileChecksum": f"sum-{prefix}",
-            }
+            },
         },
     }
 


### PR DESCRIPTION
## Summary
Live Photos are stored in CloudKit with both still-image fields
(`resOriginalRes`, `resJPEGMedRes`, …) AND live-video fields
(`resOriginalVidComplRes`, `resVidMedRes`, `resVidSmallRes`) on the same
master_record. Previous icloudpy versions detected "is this a video?" by
checking presence of `resVidSmallRes`, which is true for Live Photos too —
they were misclassified as videos and the still half was dropped.

This change:

1. Adds `ITEM_TYPES` dict mapping Apple UTIs (`public.heic`, `public.jpeg`,
   `com.apple.quicktime-movie`, RAW formats, …) to `"image"` / `"movie"`.
2. Adds `PhotoAsset.item_type` property reading `fields["itemType"]` with a
   filename-extension fallback for assets without the UTI.
3. Changes `versions` detection from the `resVidSmallRes` heuristic to
   `item_type` — correctly classifying Live Photos as images.
4. Extends `PHOTO_VERSION_LOOKUP` with three new keys —
   `live_video_original` / `live_video_medium` / `live_video_thumb` —
   mapping to `resOriginalVidCompl` / `resVidMed` / `resVidSmall`.
   These are silently absent for non-Live-Photo stills (the existing loop
   already filters on field presence), so plain photos are unaffected.

Backward compatibility: existing version keys (`original`, `medium`,
`thumb`, etc.) still work for all stills and videos. Callers that previously
could only access the still half of Live Photos now ALSO see the
`live_video_*` keys.

Closes #199 in `mandarons/icloud-docker` once that project wires up the new
versions key (companion PR submitted there).

## Approach
Ported from `icloud_photos_downloader`'s `pyicloud_ipd.services.photos`,
which has solved this for years.

## Tests
13 new tests in `tests/test_photos.py`:

- `TestItemTypeDetection` (8 tests): UTI lookup (HEIC, JPEG, MOV, RAW),
  extension fallback (HEIC ext / MOV ext), no-UTI-no-filename → None,
  unknown UTI with image extension → image.
- `TestLivePhotoVersions` (5 tests): Live Photo classified as image,
  exposes still version with correct URL, exposes all three `live_video_*`
  versions with correct URLs/types, plain still has no `live_video_*` keys,
  regular video uses `VIDEO_VERSION_LOOKUP`.

Full suite passes; only the pre-existing unrelated `test_storage` failure remains.
