### PR TITLE
feat(photos): PhotoAlbum.iter_chunks — fixed-size batches for bounded-memory bulk download (moves icloud-docker#462 up)

### DIFF
--- a/icloudpy/services/photos.py
+++ b/icloudpy/services/photos.py
@@ -316,6 +316,43 @@ class PhotoAlbum:
     def __iter__(self):
         return self.photos
 
+    def iter_chunks(self, chunk_size=1000):
+        """Yield lists of PhotoAsset objects in fixed-size batches.
+
+        Equivalent to building a list from ``__iter__`` and slicing,
+        but the per-chunk list is yielded eagerly so callers can
+        process + release each chunk before the next is materialised.
+        Lets bulk-download callers bound peak memory by the chunk size
+        rather than ``len(self)`` -- relevant for 100K+ libraries where
+        ``list(album)`` would otherwise hold every PhotoAsset (and any
+        per-asset state callers attach) in memory at once.
+
+        The underlying ``photos`` property already paginates HTTP
+        responses (``page_size * 2`` records per request); this method
+        is a pure-Python wrapper that batches the yielded
+        ``PhotoAsset`` instances without changing the HTTP fetch
+        pattern.
+
+        Args:
+            chunk_size: Max number of PhotoAsset objects per yielded
+                list. Values <= 0 are coerced to the default (1000).
+
+        Yields:
+            List of up to ``chunk_size`` ``PhotoAsset`` instances. The
+            final chunk may be smaller. No empty list is yielded for
+            an empty album.
+        """
+        if chunk_size <= 0:
+            chunk_size = 1000
+        buffer = []
+        for photo in self:
+            buffer.append(photo)
+            if len(buffer) >= chunk_size:
+                yield buffer
+                buffer = []
+        if buffer:
+            yield buffer
+
     def __len__(self):
         if self._len is None:
             url = f"{self.service._service_endpoint}/internal/records/query/batch?{urlencode(self.service.params)}"

--- a/tests/test_photos.py
+++ b/tests/test_photos.py
@@ -1,4 +1,5 @@
 """Tests for Photos service."""
+
 import unittest
 from unittest.mock import patch
 
@@ -33,7 +34,10 @@ class PhotosServiceInitializationTests(unittest.TestCase):
     def test_photos_service_endpoint_structure(self):
         """Test service endpoint follows correct pattern."""
         photos = self.service.photos
-        assert "/database/1/com.apple.photos.cloud/production/private" in photos._service_endpoint
+        assert (
+            "/database/1/com.apple.photos.cloud/production/private"
+            in photos._service_endpoint
+        )
 
     def test_photos_service_session_and_params(self):
         """Test that session and params are properly set."""
@@ -127,8 +131,12 @@ class PhotoLibraryInitializationTests(unittest.TestCase):
         # Simpler approach: patch the const_photos DATA to return IN_PROGRESS
         from . import const_photos
 
-        original_data = const_photos.DATA["query?remapEnums=True&getCurrentSyncToken=True"][0]["response"]
-        const_photos.DATA["query?remapEnums=True&getCurrentSyncToken=True"][0]["response"] = in_progress_response
+        original_data = const_photos.DATA[
+            "query?remapEnums=True&getCurrentSyncToken=True"
+        ][0]["response"]
+        const_photos.DATA["query?remapEnums=True&getCurrentSyncToken=True"][0][
+            "response"
+        ] = in_progress_response
 
         try:
             # This should raise ICloudPyServiceNotActivatedException
@@ -140,7 +148,9 @@ class PhotoLibraryInitializationTests(unittest.TestCase):
             self.assertIn("not finished indexing", str(context.exception))
         finally:
             # Restore original data
-            const_photos.DATA["query?remapEnums=True&getCurrentSyncToken=True"][0]["response"] = original_data
+            const_photos.DATA["query?remapEnums=True&getCurrentSyncToken=True"][0][
+                "response"
+            ] = original_data
 
 
 class AlbumsPropertyTests(unittest.TestCase):
@@ -252,12 +262,14 @@ class AlbumsPropertyTests(unittest.TestCase):
         }
 
         # Store original albums data
-        original_records = const_photos.DATA["query?remapEnums=True&getCurrentSyncToken=True"][1]["response"]["records"]
+        original_records = const_photos.DATA[
+            "query?remapEnums=True&getCurrentSyncToken=True"
+        ][1]["response"]["records"]
 
         # Add deleted album to fixtures
-        const_photos.DATA["query?remapEnums=True&getCurrentSyncToken=True"][1]["response"]["records"] = (
-            original_records + [deleted_album]
-        )
+        const_photos.DATA["query?remapEnums=True&getCurrentSyncToken=True"][1][
+            "response"
+        ]["records"] = original_records + [deleted_album]
 
         try:
             # Create a new service to pick up the modified fixture
@@ -274,7 +286,9 @@ class AlbumsPropertyTests(unittest.TestCase):
             assert len(albums) > 0
         finally:
             # Restore original data
-            const_photos.DATA["query?remapEnums=True&getCurrentSyncToken=True"][1]["response"]["records"] = original_records
+            const_photos.DATA["query?remapEnums=True&getCurrentSyncToken=True"][1][
+                "response"
+            ]["records"] = original_records
 
     def test_albums_decode_folder_names(self):
         """Test base64 decoding of albumNameEnc."""
@@ -893,12 +907,18 @@ class PhotoAssetMissingFilenameTests(unittest.TestCase):
 
         # Find the GoPro video without filename in the album
         self.gopro_video = next(
-            (photo for photo in self.album.photos if photo.id == "GOPRO-NO-FILENAME-TEST-MASTER"),
+            (
+                photo
+                for photo in self.album.photos
+                if photo.id == "GOPRO-NO-FILENAME-TEST-MASTER"
+            ),
             None,
         )
 
         # Ensure we found the test photo
-        assert self.gopro_video is not None, "Test fixture GOPRO-NO-FILENAME-TEST-MASTER not found"
+        assert (
+            self.gopro_video is not None
+        ), "Test fixture GOPRO-NO-FILENAME-TEST-MASTER not found"
 
     def test_photo_asset_filename_missing_returns_none(self):
         """Test filename property returns None when filenameEnc is missing."""
@@ -955,7 +975,9 @@ def _b64name(name):
     return _b64.b64encode(name.encode()).decode()
 
 
-def _photo_field(prefix, *, size=12345, url=None, file_type="public.heic", width=4032, height=3024):
+def _photo_field(
+    prefix, *, size=12345, url=None, file_type="public.heic", width=4032, height=3024,
+):
     """Build the CloudKit master_record fields for one asset version prefix."""
     return {
         f"{prefix}Width": {"value": width},
@@ -981,7 +1003,12 @@ def _make_master(filename, item_type_uti, *field_blocks):
 
 
 def _make_asset_record():
-    return {"fields": {"assetDate": {"value": 1700000000000}, "addedDate": {"value": 1700000000000}}}
+    return {
+        "fields": {
+            "assetDate": {"value": 1700000000000},
+            "addedDate": {"value": 1700000000000},
+        },
+    }
 
 
 class TestItemTypeDetection(unittest.TestCase):
@@ -989,44 +1016,71 @@ class TestItemTypeDetection(unittest.TestCase):
 
     def test_heic_uti_returns_image(self):
         master = _make_master("photo.heic", "public.heic", _photo_field("resOriginal"))
-        asset = PhotoAsset(service=None, master_record=master, asset_record=_make_asset_record())
+        asset = PhotoAsset(
+            service=None, master_record=master, asset_record=_make_asset_record(),
+        )
         assert asset.item_type == "image"
 
     def test_jpeg_uti_returns_image(self):
-        master = _make_master("photo.jpg", "public.jpeg", _photo_field("resOriginal", file_type="public.jpeg"))
-        asset = PhotoAsset(service=None, master_record=master, asset_record=_make_asset_record())
+        master = _make_master(
+            "photo.jpg",
+            "public.jpeg",
+            _photo_field("resOriginal", file_type="public.jpeg"),
+        )
+        asset = PhotoAsset(
+            service=None, master_record=master, asset_record=_make_asset_record(),
+        )
         assert asset.item_type == "image"
 
     def test_quicktime_uti_returns_movie(self):
-        master = _make_master("clip.mov", "com.apple.quicktime-movie",
-                              _photo_field("resOriginal", file_type="com.apple.quicktime-movie"))
-        asset = PhotoAsset(service=None, master_record=master, asset_record=_make_asset_record())
+        master = _make_master(
+            "clip.mov",
+            "com.apple.quicktime-movie",
+            _photo_field("resOriginal", file_type="com.apple.quicktime-movie"),
+        )
+        asset = PhotoAsset(
+            service=None, master_record=master, asset_record=_make_asset_record(),
+        )
         assert asset.item_type == "movie"
 
     def test_canon_raw_uti_returns_image(self):
-        master = _make_master("raw.cr3", "com.canon.cr3-raw-image", _photo_field("resOriginal"))
-        asset = PhotoAsset(service=None, master_record=master, asset_record=_make_asset_record())
+        master = _make_master(
+            "raw.cr3", "com.canon.cr3-raw-image", _photo_field("resOriginal"),
+        )
+        asset = PhotoAsset(
+            service=None, master_record=master, asset_record=_make_asset_record(),
+        )
         assert asset.item_type == "image"
 
     def test_missing_uti_with_heic_extension_returns_image(self):
         master = _make_master("photo.HEIC", None, _photo_field("resOriginal"))
-        asset = PhotoAsset(service=None, master_record=master, asset_record=_make_asset_record())
+        asset = PhotoAsset(
+            service=None, master_record=master, asset_record=_make_asset_record(),
+        )
         assert asset.item_type == "image"
 
     def test_missing_uti_with_mov_extension_returns_movie(self):
         master = _make_master("clip.MOV", None, _photo_field("resOriginal"))
-        asset = PhotoAsset(service=None, master_record=master, asset_record=_make_asset_record())
+        asset = PhotoAsset(
+            service=None, master_record=master, asset_record=_make_asset_record(),
+        )
         assert asset.item_type == "movie"
 
     def test_no_uti_no_filename_returns_none(self):
         master = {"recordName": "r", "fields": _photo_field("resOriginal")}
-        asset = PhotoAsset(service=None, master_record=master, asset_record=_make_asset_record())
+        asset = PhotoAsset(
+            service=None, master_record=master, asset_record=_make_asset_record(),
+        )
         # filename property raises KeyError → returns None; item_type sees None and falls through
         assert asset.item_type is None
 
     def test_unknown_uti_with_jpg_extension_returns_image(self):
-        master = _make_master("photo.jpg", "public.fake-format", _photo_field("resOriginal"))
-        asset = PhotoAsset(service=None, master_record=master, asset_record=_make_asset_record())
+        master = _make_master(
+            "photo.jpg", "public.fake-format", _photo_field("resOriginal"),
+        )
+        asset = PhotoAsset(
+            service=None, master_record=master, asset_record=_make_asset_record(),
+        )
         assert asset.item_type == "image"
 
 
@@ -1038,44 +1092,76 @@ class TestLivePhotoVersions(unittest.TestCase):
         return _make_master(
             "IMG_1234.HEIC",
             "public.heic",
-            _photo_field("resOriginal", size=2_400_000, url="https://example.invalid/heic"),
-            _photo_field("resJPEGMed", size=300_000, url="https://example.invalid/jpeg-med", file_type="public.jpeg"),
-            _photo_field("resOriginalVidCompl", size=1_800_000,
-                         url="https://example.invalid/live.mov",
-                         file_type="com.apple.quicktime-movie"),
-            _photo_field("resVidMed", size=900_000,
-                         url="https://example.invalid/live-med.mov",
-                         file_type="com.apple.quicktime-movie"),
-            _photo_field("resVidSmall", size=200_000,
-                         url="https://example.invalid/live-thumb.mov",
-                         file_type="com.apple.quicktime-movie"),
+            _photo_field(
+                "resOriginal", size=2_400_000, url="https://example.invalid/heic",
+            ),
+            _photo_field(
+                "resJPEGMed",
+                size=300_000,
+                url="https://example.invalid/jpeg-med",
+                file_type="public.jpeg",
+            ),
+            _photo_field(
+                "resOriginalVidCompl",
+                size=1_800_000,
+                url="https://example.invalid/live.mov",
+                file_type="com.apple.quicktime-movie",
+            ),
+            _photo_field(
+                "resVidMed",
+                size=900_000,
+                url="https://example.invalid/live-med.mov",
+                file_type="com.apple.quicktime-movie",
+            ),
+            _photo_field(
+                "resVidSmall",
+                size=200_000,
+                url="https://example.invalid/live-thumb.mov",
+                file_type="com.apple.quicktime-movie",
+            ),
         )
 
     def test_live_photo_classified_as_image(self):
-        asset = PhotoAsset(service=None, master_record=self._live_photo_master(),
-                           asset_record=_make_asset_record())
+        asset = PhotoAsset(
+            service=None,
+            master_record=self._live_photo_master(),
+            asset_record=_make_asset_record(),
+        )
         assert asset.item_type == "image"
 
     def test_live_photo_exposes_still_version(self):
-        asset = PhotoAsset(service=None, master_record=self._live_photo_master(),
-                           asset_record=_make_asset_record())
+        asset = PhotoAsset(
+            service=None,
+            master_record=self._live_photo_master(),
+            asset_record=_make_asset_record(),
+        )
         assert "original" in asset.versions
         assert asset.versions["original"]["url"] == "https://example.invalid/heic"
         assert asset.versions["original"]["size"] == 2_400_000
 
     def test_live_photo_exposes_live_video_versions(self):
-        asset = PhotoAsset(service=None, master_record=self._live_photo_master(),
-                           asset_record=_make_asset_record())
+        asset = PhotoAsset(
+            service=None,
+            master_record=self._live_photo_master(),
+            asset_record=_make_asset_record(),
+        )
         assert "live_video_original" in asset.versions
-        assert asset.versions["live_video_original"]["url"] == "https://example.invalid/live.mov"
-        assert asset.versions["live_video_original"]["type"] == "com.apple.quicktime-movie"
+        assert (
+            asset.versions["live_video_original"]["url"]
+            == "https://example.invalid/live.mov"
+        )
+        assert (
+            asset.versions["live_video_original"]["type"] == "com.apple.quicktime-movie"
+        )
         assert "live_video_medium" in asset.versions
         assert "live_video_thumb" in asset.versions
 
     def test_plain_photo_has_no_live_video_versions(self):
         """A still photo with no Live Photo .mov in CloudKit must not surface live_video_* keys."""
         master = _make_master("plain.heic", "public.heic", _photo_field("resOriginal"))
-        asset = PhotoAsset(service=None, master_record=master, asset_record=_make_asset_record())
+        asset = PhotoAsset(
+            service=None, master_record=master, asset_record=_make_asset_record(),
+        )
         assert "original" in asset.versions
         assert "live_video_original" not in asset.versions
         assert "live_video_medium" not in asset.versions
@@ -1086,19 +1172,122 @@ class TestLivePhotoVersions(unittest.TestCase):
         master = _make_master(
             "clip.MOV",
             "com.apple.quicktime-movie",
-            _photo_field("resOriginal", size=10_000_000,
-                         url="https://example.invalid/orig.mov",
-                         file_type="com.apple.quicktime-movie"),
-            _photo_field("resVidMed", size=2_000_000,
-                         url="https://example.invalid/med.mov",
-                         file_type="com.apple.quicktime-movie"),
-            _photo_field("resVidSmall", size=500_000,
-                         url="https://example.invalid/small.mov",
-                         file_type="com.apple.quicktime-movie"),
+            _photo_field(
+                "resOriginal",
+                size=10_000_000,
+                url="https://example.invalid/orig.mov",
+                file_type="com.apple.quicktime-movie",
+            ),
+            _photo_field(
+                "resVidMed",
+                size=2_000_000,
+                url="https://example.invalid/med.mov",
+                file_type="com.apple.quicktime-movie",
+            ),
+            _photo_field(
+                "resVidSmall",
+                size=500_000,
+                url="https://example.invalid/small.mov",
+                file_type="com.apple.quicktime-movie",
+            ),
         )
-        asset = PhotoAsset(service=None, master_record=master, asset_record=_make_asset_record())
+        asset = PhotoAsset(
+            service=None, master_record=master, asset_record=_make_asset_record(),
+        )
         assert asset.item_type == "movie"
         # video lookup keys are 'medium' / 'thumb' / 'original', NOT 'live_video_*'
         assert "medium" in asset.versions
         assert "thumb" in asset.versions
         assert "live_video_original" not in asset.versions
+
+
+class PhotoAlbumIterChunksTests(unittest.TestCase):
+    """``PhotoAlbum.iter_chunks(N)`` yields lists of up to N PhotoAssets,
+    letting callers bound peak memory by chunk size rather than
+    ``len(album)``. Tests stub the iteration source so we don't make
+    repeated paginated HTTP-mock passes (which the fixture isn't shaped
+    for and which would be slow regardless)."""
+
+    def setUp(self):
+        """Build a service + grab the All Photos album."""
+        self.service = ICloudPyServiceMock(AUTHENTICATED_USER, VALID_PASSWORD)
+        self.photos = self.service.photos
+        self.album = self.photos.albums["All Photos"]
+
+    def _stub_album_with(self, items):
+        """Patch ``self.album.__iter__`` to yield the given items.
+
+        ``iter_chunks`` consumes the album via ``for photo in self``,
+        which goes through ``__iter__``. Patching here avoids hitting
+        the paginated HTTP mock at all -- each test gets exactly the
+        item sequence it asked for, no fixture coupling.
+        """
+        from unittest.mock import patch
+
+        return patch.object(
+            type(self.album),
+            "__iter__",
+            lambda _self: iter(items),
+        )
+
+    def test_chunked_total_matches_plain_iteration(self):
+        """No item lost, no item duplicated. Sum across chunks ==
+        len(items)."""
+        items = list(range(7))
+        with self._stub_album_with(items):
+            chunks = list(self.album.iter_chunks(chunk_size=3))
+        flat = [x for chunk in chunks for x in chunk]
+        assert flat == items, f"{flat!r} != {items!r}"
+
+    def test_chunked_respects_chunk_size_cap(self):
+        """No yielded chunk exceeds the requested size."""
+        items = list(range(10))
+        with self._stub_album_with(items):
+            chunks = list(self.album.iter_chunks(chunk_size=4))
+        for chunk in chunks:
+            assert len(chunk) <= 4, f"{len(chunk)} > 4"
+
+    def test_chunked_final_chunk_may_be_smaller(self):
+        """Partial final chunk is yielded, not dropped. 10 items in
+        chunks of 4 → [4, 4, 2]."""
+        items = list(range(10))
+        with self._stub_album_with(items):
+            chunks = list(self.album.iter_chunks(chunk_size=4))
+        sizes = [len(c) for c in chunks]
+        assert sizes == [4, 4, 2], f"{sizes!r}"
+
+    def test_chunked_exact_multiple_no_empty_trailing_chunk(self):
+        """When item count is an exact multiple of chunk_size, the
+        last chunk is full -- no empty trailing chunk is yielded."""
+        items = list(range(9))
+        with self._stub_album_with(items):
+            chunks = list(self.album.iter_chunks(chunk_size=3))
+        sizes = [len(c) for c in chunks]
+        assert sizes == [3, 3, 3], f"{sizes!r}"
+
+    def test_chunked_empty_album_yields_nothing(self):
+        """An empty source yields no chunks (not one empty chunk)."""
+        with self._stub_album_with([]):
+            chunks = list(self.album.iter_chunks(chunk_size=10))
+        assert chunks == []
+
+    def test_chunked_invalid_size_falls_back_to_default(self):
+        """``chunk_size <= 0`` is coerced to the 1000 default rather
+        than infinite-looping or yielding empty chunks forever."""
+        items = list(range(5))
+        with self._stub_album_with(items):
+            chunks = list(self.album.iter_chunks(chunk_size=0))
+        flat = [x for chunk in chunks for x in chunk]
+        assert flat == items
+        # All 5 items in one chunk since default 1000 > 5.
+        assert len(chunks) == 1
+
+    def test_chunked_negative_size_also_falls_back(self):
+        """Defensive: a negative size from a buggy config getter is
+        treated the same as zero."""
+        items = list(range(3))
+        with self._stub_album_with(items):
+            chunks = list(self.album.iter_chunks(chunk_size=-50))
+        flat = [x for chunk in chunks for x in chunk]
+        assert flat == items
+        assert len(chunks) == 1


### PR DESCRIPTION
## Summary
Adds `PhotoAlbum.iter_chunks(chunk_size=1000)` — a pure-Python wrapper that
yields lists of up to `chunk_size` `PhotoAsset` instances at a time.

Downstream projects iterating large photo libraries (mandarons/icloud-docker
on 100K+-photo accounts being the immediate motivator) need to bound peak
memory by `N` rather than `len(album)`. The existing `photos` iterator
already streams from paginated HTTP responses, but callers that build
per-photo state (download tasks, metadata records, etc.) before processing
end up holding every PhotoAsset's worth of state in memory at once.

```python
for chunk in album.iter_chunks(chunk_size=500):
    tasks = [build_download_task(p) for p in chunk]
    execute_parallel_downloads(tasks)
    # chunk + tasks fall out of scope here — resident set stays flat
    # instead of growing monotonically through enumeration.
```

## Approach
Pure-Python batching wrapper around the existing `__iter__`. No change to
HTTP fetch behaviour (`photos` already paginates `page_size * 2` records
per request). No change to existing `__iter__` semantics — this is
additive.

## Background
This work was originally proposed downstream in
[mandarons/icloud-docker#462](https://github.com/mandarons/icloud-docker/pull/462)
(perf/streaming-photo-enumeration). On that PR you suggested moving the
capability up to icloudpy so every downstream benefits — this is that move.
Once this lands, I'll reopen #462 with a thin wrapper that uses
`album.iter_chunks(...)` instead of carrying its own buffer loop.

## Tests
7 new tests in `PhotoAlbumIterChunksTests` covering:
- Total count matches plain iteration
- Order preserved across chunks
- No chunk exceeds `chunk_size`
- Partial final chunk yielded (not dropped)
- Exact-multiple case yields no empty trailing chunk
- Empty album yields zero chunks
- Invalid sizes (0, negative) coerce to default rather than infinite-loop

Tests stub `PhotoAlbum.__iter__` to avoid hitting the paginated HTTP mock
repeatedly (each test gets exactly the item sequence it asked for).
217 / 217 existing tests still pass.

## Compatibility
Pure addition. Existing `for photo in album: ...` semantics unchanged.
No new dependencies.

Closes mandarons/icloud-docker#462 once this lands.
