### PR TITLE
feat: authenticate with a hardware security key

### DIFF
--- a/icloudpy/base.py
+++ b/icloudpy/base.py
@@ -181,6 +181,50 @@ class ICloudPySession(Session):
         return self._raise_error(code=code, reason=reason)
 
 
+# Apple serves its sign-in widget from here, so this is the origin a browser
+# reports when signing a challenge for it.
+SECURITY_KEY_ORIGIN = "https://idmsa.apple.com"
+
+# Apple answers an accepted security key assertion with 409, alongside the
+# ordinary success codes. 250 is its own "two-factor completed".
+SECURITY_KEY_ACCEPTED_STATUSES = frozenset({200, 204, 250, 409})
+
+
+def _b64_decode(value):
+    """Decode Apple's base64, which is unpadded and may use either alphabet."""
+    return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+
+
+def _b64_encode(value):
+    """Encode bytes the way Apple's own client does."""
+    return base64.b64encode(value).decode("ascii")
+
+
+def build_security_key_assertion(response, rp_id, request_id=None):
+    """Build the payload Apple expects from a WebAuthn assertion response.
+
+    ``response`` is a ``fido2`` ``AuthenticatorAssertionResponse`` or any
+    object exposing the same ``response`` and ``raw_id`` attributes.
+
+    The challenge is taken from ``clientData`` rather than passed in, which
+    keeps the value signed and the value declared in step.
+    """
+    client_data = bytes(response.response.client_data)
+    challenge = json.loads(client_data).get("challenge", "")
+    user_handle = response.response.user_handle
+
+    return {
+        "challenge": challenge.replace("-", "+").replace("_", "/"),
+        "clientData": _b64_encode(client_data),
+        "signatureData": _b64_encode(bytes(response.response.signature)),
+        "authenticatorData": _b64_encode(bytes(response.response.authenticator_data)),
+        "userHandle": _b64_encode(bytes(user_handle)).rstrip("=") if user_handle else "",
+        "credentialID": _b64_encode(bytes(response.raw_id)),
+        "rpId": rp_id,
+        "requestId": request_id or "",
+    }
+
+
 class ICloudPyService:
     """
     A base authentication class for the iCloud service. Handles the
@@ -623,6 +667,125 @@ class ICloudPyService:
 
         self.trust_session()
         return not self.requires_2sa
+
+    @property
+    def security_key_challenge(self):
+        """Apple's pending WebAuthn challenge, or None if it is not asking for one.
+
+        Returned when the account has security keys enrolled, in which case
+        Apple issues this instead of delivering a 6-digit code. The dict
+        carries ``challenge``, ``keyHandles`` and ``rpId``.
+        """
+        headers = self._get_auth_headers({"Accept": "application/json"})
+        if self.session_data.get("scnt"):
+            headers["scnt"] = self.session_data.get("scnt")
+        if self.session_data.get("session_id"):
+            headers["X-Apple-ID-Session-Id"] = self.session_data.get("session_id")
+
+        try:
+            response = self.session.get(self.auth_endpoint, headers=headers)
+            challenge = response.json().get("fsaChallenge")
+        except (ICloudPyAPIResponseException, ValueError) as error:
+            LOGGER.debug("Could not read security key challenge: %s", error)
+            return None
+
+        if not (challenge and challenge.get("challenge") and challenge.get("keyHandles")):
+            return None
+        return challenge
+
+    @property
+    def fido2_devices(self):
+        """Attached FIDO2 devices.
+
+        Empty when the optional ``fido2`` package is not installed.
+        """
+        try:
+            from fido2.hid import CtapHidDevice
+        except ImportError:
+            LOGGER.debug("fido2 is not installed; no local devices available.")
+            return []
+        return list(CtapHidDevice.list_devices())
+
+    def confirm_security_key(self, assertion=None, device=None):
+        """Complete two-factor authentication with a security key.
+
+        Signs the pending challenge with an attached FIDO2 device and
+        submits the result. Pass ``assertion`` to submit one that has
+        already been built -- by ``sign_security_key_challenge`` or by any
+        other means -- in which case no device is used.
+
+        Returns True when the session no longer requires a second factor.
+        """
+        if assertion is None:
+            challenge = self.security_key_challenge
+            if not challenge:
+                msg = "Apple is not requesting a security key."
+                raise ICloudPyFailedLoginException(msg)
+            if device is None:
+                devices = self.fido2_devices
+                if not devices:
+                    msg = "No FIDO2 device found."
+                    raise ICloudPyFailedLoginException(msg)
+                device = devices[0]
+            assertion = self.sign_security_key_challenge(challenge, device)
+
+        headers = self._get_auth_headers({"Accept": "application/json"})
+        if self.session_data.get("scnt"):
+            headers["scnt"] = self.session_data.get("scnt")
+        if self.session_data.get("session_id"):
+            headers["X-Apple-ID-Session-Id"] = self.session_data.get("session_id")
+
+        try:
+            response = self.session.post(
+                f"{self.auth_endpoint}/verify/security/key",
+                data=json.dumps(assertion),
+                headers=headers,
+            )
+            status = response.status_code
+        except ICloudPyAPIResponseException as error:
+            status = error.code
+
+        if status not in SECURITY_KEY_ACCEPTED_STATUSES:
+            LOGGER.error("Security key verification failed (%s).", status)
+            return False
+
+        LOGGER.debug("Security key verification successful.")
+        self.trust_session()
+        return not self.requires_2sa
+
+    def sign_security_key_challenge(self, challenge, device):
+        """Sign ``challenge`` with ``device`` and return the assertion payload.
+
+        Requires the ``fido2`` package and a physical touch on the key. The
+        result is accepted by ``confirm_security_key``.
+        """
+        from fido2.client import DefaultClientDataCollector, Fido2Client
+        from fido2.webauthn import (
+            PublicKeyCredentialDescriptor,
+            PublicKeyCredentialRequestOptions,
+            PublicKeyCredentialType,
+            UserVerificationRequirement,
+        )
+
+        rp_id = challenge.get("rpId") or "apple.com"
+        client = Fido2Client(
+            device,
+            client_data_collector=DefaultClientDataCollector(SECURITY_KEY_ORIGIN),
+        )
+        options = PublicKeyCredentialRequestOptions(
+            challenge=_b64_decode(challenge["challenge"]),
+            rp_id=rp_id,
+            allow_credentials=[
+                PublicKeyCredentialDescriptor(
+                    id=_b64_decode(handle),
+                    type=PublicKeyCredentialType("public-key"),
+                )
+                for handle in challenge["keyHandles"]
+            ],
+            user_verification=UserVerificationRequirement("discouraged"),
+        )
+        result = client.get_assertion(options).get_response(0)
+        return build_security_key_assertion(result, rp_id, challenge.get("requestId"))
 
     def trust_session(self):
         """Request session trust to avoid user log in going forward."""

--- a/tests/test_security_key.py
+++ b/tests/test_security_key.py
@@ -1,0 +1,176 @@
+"""Security key (WebAuthn) authentication tests for base.py."""
+
+import base64
+import json
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from icloudpy.base import (
+    SECURITY_KEY_ACCEPTED_STATUSES,
+    build_security_key_assertion,
+)
+from icloudpy.exceptions import ICloudPyFailedLoginException
+
+CHALLENGE = {
+    "challenge": base64.b64encode(b"c" * 32).decode().rstrip("="),
+    "keyHandles": [base64.b64encode(b"h" * 48).decode().rstrip("=")],
+    "rpId": "apple.com",
+}
+
+
+def _assertion_response(user_handle=b"user"):
+    """A stand-in for fido2's AuthenticatorAssertionResponse."""
+    response = MagicMock()
+    response.response.client_data = json.dumps(
+        {"type": "webauthn.get", "challenge": "a-b_c"},
+    ).encode()
+    response.response.signature = b"sig"
+    response.response.authenticator_data = b"auth"
+    response.response.user_handle = user_handle
+    response.raw_id = b"cred"
+    return response
+
+
+class TestBuildAssertion(TestCase):
+    """``build_security_key_assertion`` produces Apple's payload."""
+
+    def test_challenge_comes_from_client_data(self):
+        """Keeps the value signed and the value declared in step."""
+        payload = build_security_key_assertion(_assertion_response(), "apple.com")
+        assert payload["challenge"] == "a+b/c"
+
+    def test_binary_fields_are_standard_base64(self):
+        payload = build_security_key_assertion(_assertion_response(), "apple.com")
+        assert base64.b64decode(payload["signatureData"]) == b"sig"
+        assert base64.b64decode(payload["authenticatorData"]) == b"auth"
+        assert base64.b64decode(payload["credentialID"]) == b"cred"
+
+    def test_user_handle_is_unpadded(self):
+        payload = build_security_key_assertion(_assertion_response(), "apple.com")
+        assert not payload["userHandle"].endswith("=")
+
+    def test_absent_user_handle_is_empty(self):
+        payload = build_security_key_assertion(
+            _assertion_response(user_handle=None),
+            "apple.com",
+        )
+        assert payload["userHandle"] == ""
+
+    def test_request_id_is_always_present(self):
+        payload = build_security_key_assertion(_assertion_response(), "apple.com")
+        assert payload["requestId"] == ""
+        payload = build_security_key_assertion(_assertion_response(), "apple.com", "r1")
+        assert payload["requestId"] == "r1"
+
+
+class TestAcceptedStatuses(TestCase):
+    """Apple answers an accepted assertion with 409."""
+
+    def test_409_is_accepted(self):
+        assert 409 in SECURITY_KEY_ACCEPTED_STATUSES
+
+    def test_ordinary_success_codes_are_accepted(self):
+        assert {200, 204, 250} <= SECURITY_KEY_ACCEPTED_STATUSES
+
+    def test_failures_are_not_accepted(self):
+        assert not {400, 401, 403, 412, 500} & SECURITY_KEY_ACCEPTED_STATUSES
+
+
+class TestSecurityKeyChallenge(TestCase):
+    """``security_key_challenge`` reports what Apple is asking for."""
+
+    def _service(self, payload):
+        service = MagicMock()
+        service.session.get.return_value.json.return_value = payload
+        service.session_data = {"scnt": "s", "session_id": "i"}
+        service.auth_endpoint = "https://idmsa.apple.com/appleauth/auth"
+        return service
+
+    def test_returns_the_challenge_when_present(self):
+        from icloudpy.base import ICloudPyService
+
+        service = self._service({"fsaChallenge": CHALLENGE})
+        assert ICloudPyService.security_key_challenge.fget(service) == CHALLENGE
+
+    def test_returns_none_when_absent(self):
+        from icloudpy.base import ICloudPyService
+
+        service = self._service({})
+        assert ICloudPyService.security_key_challenge.fget(service) is None
+
+    def test_returns_none_when_incomplete(self):
+        from icloudpy.base import ICloudPyService
+
+        service = self._service({"fsaChallenge": {"challenge": "x"}})
+        assert ICloudPyService.security_key_challenge.fget(service) is None
+
+
+class TestConfirmSecurityKey(TestCase):
+    """``confirm_security_key`` submits an assertion and trusts the session."""
+
+    def _service(self, status):
+        service = MagicMock()
+        service.session.post.return_value.status_code = status
+        service.session_data = {"scnt": "s", "session_id": "i"}
+        service.auth_endpoint = "https://idmsa.apple.com/appleauth/auth"
+        service._get_auth_headers.return_value = {}
+        service.requires_2sa = False
+        return service
+
+    def _confirm(self, service, **kwargs):
+        from icloudpy.base import ICloudPyService
+
+        return ICloudPyService.confirm_security_key(service, **kwargs)
+
+    def test_409_completes_authentication(self):
+        service = self._service(409)
+        assert self._confirm(service, assertion={"credentialID": "x"}) is True
+        service.trust_session.assert_called_once()
+
+    def test_success_codes_complete_authentication(self):
+        for status in (200, 204, 250):
+            service = self._service(status)
+            assert self._confirm(service, assertion={"credentialID": "x"}) is True
+
+    def test_a_refusal_returns_false(self):
+        service = self._service(400)
+        assert self._confirm(service, assertion={"credentialID": "x"}) is False
+        service.trust_session.assert_not_called()
+
+    def test_a_supplied_assertion_uses_no_device(self):
+        service = self._service(409)
+        self._confirm(service, assertion={"credentialID": "x"})
+        service.sign_security_key_challenge.assert_not_called()
+
+    def test_signs_when_no_assertion_is_supplied(self):
+        service = self._service(409)
+        service.security_key_challenge = CHALLENGE
+        service.fido2_devices = ["device"]
+        service.sign_security_key_challenge.return_value = {"credentialID": "x"}
+        assert self._confirm(service) is True
+        service.sign_security_key_challenge.assert_called_once_with(CHALLENGE, "device")
+
+    def test_raises_when_apple_is_not_asking(self):
+        service = self._service(409)
+        service.security_key_challenge = None
+        with pytest.raises(ICloudPyFailedLoginException):
+            self._confirm(service)
+
+    def test_raises_when_no_device_is_attached(self):
+        service = self._service(409)
+        service.security_key_challenge = CHALLENGE
+        service.fido2_devices = []
+        with pytest.raises(ICloudPyFailedLoginException):
+            self._confirm(service)
+
+
+class TestFido2Devices(TestCase):
+    """``fido2_devices`` degrades when the optional package is absent."""
+
+    def test_empty_without_fido2(self):
+        from icloudpy.base import ICloudPyService
+
+        with patch.dict("sys.modules", {"fido2.hid": None}):
+            assert ICloudPyService.fido2_devices.fget(MagicMock()) == []


### PR DESCRIPTION
Once security keys are enrolled on an Apple ID, Apple stops offering a 6-digit code and returns an `fsaChallenge` — a WebAuthn assertion request — from every 2FA endpoint. `validate_2fa_code` then has nothing to validate, and such an account cannot complete two-factor at all.

New surface:

```python
api.security_key_challenge               # pending challenge, or None
api.confirm_security_key()               # sign with an attached key, submit, trust
api.confirm_security_key(assertion=...)  # submit an assertion built elsewhere
api.sign_security_key_challenge(c, dev)  # sign without submitting
api.fido2_devices                        # attached devices
build_security_key_assertion(...)        # assertion response -> Apple's payload
```

`fido2` is imported lazily and only on the signing path, so it stays optional and callers that supply an assertion don't need it installed.

Two details that are easy to get wrong, both taken from Apple's sign-in bundle:

- an accepted assertion returns **409**, not 2xx (`250` is Apple's own "two-factor completed")
- the challenge in the payload is read back out of `clientData`, so the value signed and the value declared can't diverge

19 tests added, no network. Verified end to end against a real account and a YubiKey: one touch, `hsaTrustedBrowser=True`, session trusted.

Note `tests/test_account.py::test_storage` fails on `main` already, unrelated to this change.